### PR TITLE
Update MAC address and ADC pin settings

### DIFF
--- a/examples/bi-dcdc/adc.c
+++ b/examples/bi-dcdc/adc.c
@@ -21,41 +21,17 @@ extern int I0, I1;
 
 void ADCvaluesInit(void);
 
-void ADCInit_work(void)
-{
-	LPC_PINCON->PINSEL1 |= 0x00154000;		// Select ADC function for pins (ADC0-3)
-	LPC_PINCON->PINSEL3 |= 0xF0000000;		// Select ADC function for pins (ADC4-5)
-	LPC_PINCON->PINMODE1 |= 0x0002A8000;	// Neither pull-up nor pull-down resistor
-	LPC_PINCON->PINMODE3 |= 0xA00000000;	// Neither pull-up nor pull-down resistor
-	LPC_SC->PCONP |= (1 << 12);				// Set up bit PCADC
-	LPC_SC->PCLKSEL0 |= (01 << 24);			// PCLK = CCLK (102 MHz)
-	/* 7-0 SEL
-	 * 15-8 CLKDIV = 7 (12.25 MHz)
-	 * 15-8 CLKDIV = 3 (25.5 MHz)
-	 * 16 BURST software
-	 * 21 PDN on (ADC on)
-	 */
-	LPC_ADC->ADCR |= 0x00200300;
-	LPC_ADC->ADINTEN = 0x00000100;			// ADC Interrupt Enabled
-	NVIC_EnableIRQ(ADC_IRQn);
-	NVIC_SetPriority(ADC_IRQn, 0);
-	ADCvaluesInit();						// Init ADC glitch filter
-	UpdateChannel = -1;
-	ADCRead(0);								// Start first conversion
-}
-
 void ADCInit(void)
 {
-	LPC_PINCON->PINSEL1  |= 0x00154000;		// Select ADC function for pins (ADC0-3)
-	LPC_PINCON->PINMODE1 |= 0x0002A8000;	// Neither pull-up nor pull-down resistor
-	LPC_PINCON->PINSEL3  |= 0xF0000000;		// Select ADC function for pins (ADC4-5)
-	LPC_PINCON->PINMODE3 |= 0xA00000000;	// Neither pull-up nor pull-down resistor
+	LPC_PINCON->PINSEL1  |= 0x00154000;	// Select ADC function for pins (ADC0-3)
+	LPC_PINCON->PINMODE1 |= 0x002A8000;	// Neither pull-up nor pull-down resistor
+	LPC_PINCON->PINSEL3  |= 0xF0000000;	// Select ADC function for pins (ADC4-5)
+	LPC_PINCON->PINMODE3 |= 0xA0000000;	// Neither pull-up nor pull-down resistor
 
-	LPC_PINCON->PINSEL0  &= ~(0x0000000F0);
-	LPC_PINCON->PINSEL0  |=    0x000000A0;		// Select ADC function for pins (ADC6-7)
-	//LPC_PINCON->PINMODE0 |= 0b 1010 0000 0000 0000;    // Neither pull-up nor pull-down resistor
-	LPC_PINCON->PINMODE0 &=  ~(0xF000);    // Neither pull-up nor pull-down resistor
-	LPC_PINCON->PINMODE0 |= 0xA000;        // Neither pull-up nor pull-down resistor
+	LPC_PINCON->PINSEL0  &= ~(0x000000F0);  // clear prior PINSEL0 for ADC6-7
+	LPC_PINCON->PINSEL0  |=   0x000000A0;	// Select ADC function for pins (ADC6-7)
+	LPC_PINCON->PINMODE0 &= ~(0x000000F0);	// clear prior PINMODE0 for ADC6-7
+	LPC_PINCON->PINMODE0 |=   0x000000A0;	// Neither pull-up nor pull-down resistor
 
 	LPC_SC->PCONP |= (1 << 12);				// Set up bit PCADC
 	LPC_SC->PCLKSEL0 |= (01 << 24);			// PCLK = CCLK (102 MHz)

--- a/platform/bi-dcdc/contiki-main.c
+++ b/platform/bi-dcdc/contiki-main.c
@@ -80,10 +80,18 @@ main()
   //uip_ds6_addr_t *lladdr;
   //lladdr = uip_ds6_get_link_local(-1);
 
-  printf("EEPROM link-local IPv6 address: ");
+  printf("EEPROM EUI64 address: ");
   for(i=0; i<8; i++)
     printf("%02X", lladdr[i]);
   printf("\n");
+
+  // set MAC address according to EEPROM EUI64 address
+  uip_lladdr.addr[0] = lladdr[0];
+  uip_lladdr.addr[1] = lladdr[1];
+  uip_lladdr.addr[2] = lladdr[2];
+  uip_lladdr.addr[3] = lladdr[5];
+  uip_lladdr.addr[4] = lladdr[6];
+  uip_lladdr.addr[5] = lladdr[7];
 
   // Configure global IPv6 address
   //uip_ipaddr_t ipaddr;


### PR DESCRIPTION
platform/bi-dcdc/contiki-main.c:
- set MAC address according to EEPROM EUI64 address
  examples/bi-dcdc/adc.c
- remove unused function ADCInit_work()
- update ADC Pin settings (for both function and mode select registers)
